### PR TITLE
Fix snapshot link when camera ID changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ sendTo('synology.0', 'getSnapshot', {camId: 2}, (res) => {
      ### **WORK IN PROGRESS**
 -->
 ### **WORK IN PROGRESS**
+- (Voodoo2man) Rebuild the snapshot link immediately when a camera ID changes.
 - (copilot) Adapter requires node.js >= 22 now
 - (iobroker-bot) Adapter requires node.js >= 20 now.
 - (copilot) Adapter requires admin >= 7.7.22 now

--- a/lib/snapshotLink.js
+++ b/lib/snapshotLink.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function createSnapshotLink(syno, cameraId) {
+    let sid = syno.sessions.SurveillanceStation ? syno.sessions.SurveillanceStation._sid : '';
+    if (typeof sid === 'undefined') {
+        sid = syno.sessions.SurveillanceStation;
+    }
+    return `${syno.protocol}://${syno.host}:${syno.port}/webapi/entry.cgi?api=SYNO.SurveillanceStation.Camera&method=GetSnapshot&version=7&cameraId=${cameraId}&_sid=${sid}`;
+}
+
+module.exports = { createSnapshotLink };

--- a/lib/snapshotLink.test.js
+++ b/lib/snapshotLink.test.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const { expect } = require('chai');
+const { createSnapshotLink } = require('./snapshotLink.js');
+
+describe('snapshotLink', () => {
+    it('uses the current camera id without whitespace', () => {
+        const link = createSnapshotLink({ protocol: 'https', host: 'nas', port: 5001, sessions: { SurveillanceStation: { _sid: 'sid' } } }, 42);
+        expect(link).to.equal('https://nas:5001/webapi/entry.cgi?api=SYNO.SurveillanceStation.Camera&method=GetSnapshot&version=7&cameraId=42&_sid=sid');
+    });
+});

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ const moment = require('moment');
 const path = require('path');
 const simpleSSH = require('simple-ssh');
 const wol = require('wol');
+const { createSnapshotLink } = require('./lib/snapshotLink.js');
 
 let adapter;
 let syno;
@@ -450,11 +451,7 @@ function addLinkSnapShot() {
     Object.keys(states.SurveillanceStation.cameras).forEach((nameCam) => {
         if (nameCam !== undefined) {
             const camId = states.SurveillanceStation.cameras[nameCam].id;
-            let _sid = syno.sessions.SurveillanceStation ? syno.sessions.SurveillanceStation._sid :'';
-            if (typeof _sid === 'undefined') {
-                _sid = syno.sessions.SurveillanceStation;
-            }
-            states.SurveillanceStation.cameras[nameCam]['linkSnapshot'] = `${syno.protocol}://${syno.host}:${syno.port}/webapi/entry.cgi?api=SYNO.SurveillanceStation.Camera&method=GetSnapshot&version=7&cameraId= ${camId}&_sid=${_sid}`;
+            states.SurveillanceStation.cameras[nameCam].linkSnapshot = createSnapshotLink(syno, camId);
         }
     });
 }
@@ -520,6 +517,8 @@ function parselistCameras(res) {
             }
             states.SurveillanceStation.cameras[arr[i].name].host = arr[i].host || arr[i].ip;
             states.SurveillanceStation.cameras[arr[i].name].id = arr[i].id;
+            // Rebuild immediately, including when a camera was recreated with the same name.
+            states.SurveillanceStation.cameras[arr[i].name].linkSnapshot = createSnapshotLink(syno, arr[i].id);
             states.SurveillanceStation.cameras[arr[i].name].port = arr[i].port;
             states.SurveillanceStation.cameras[arr[i].name].model = arr[i].model;
             states.SurveillanceStation.cameras[arr[i].name].vendor = arr[i].vendor;


### PR DESCRIPTION
## Problem
When a Surveillance Station camera is deleted and recreated with the same name, its camera ID changes. The adapter updates the camera object ID but can leave `linkSnapshot` pointing to the previous ID.

## Changes
- Rebuild `linkSnapshot` immediately while processing `listCameras`.
- Centralize snapshot URL creation in `lib/snapshotLink.js`.
- Remove the whitespace before `cameraId`.
- Add a unit test for the generated URL.

This keeps the existing polling and snapshot behavior unchanged.